### PR TITLE
mod as artifact CI

### DIFF
--- a/.github/workflows/mod CI
+++ b/.github/workflows/mod CI
@@ -1,0 +1,20 @@
+name: Publish Island.zip artifact
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:    
+      - 'Finish-Line'
+
+jobs:
+       
+  archive-build-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+    
+      - name: Use the Upload Artifact GitHub Action
+        uses: actions/upload-artifact@v3
+        with: 
+          name: Island
+          path: ~/Mod/

--- a/Godot CI.yml
+++ b/Godot CI.yml
@@ -1,0 +1,34 @@
+name: Build Island.zip Artifact
+
+on: [push, pull_request]
+       
+env: 
+  GODOT_VERSION: 3.4.4 
+  EXPORT_NAME: Mod # directory where the Godot project is
+
+jobs:
+
+  export-linux:
+    name: Linux Export
+    runs-on: ubuntu-latest
+    container:
+      image: barichello/godot-ci:mono-latest # not sure this image works with godot 3.4.4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/templates
+          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
+      - name: Resolve Dependencies
+        run: |
+          mkdir -v -p build/linux
+          cd $EXPORT_NAME
+          timeout 30s godot . --editor --no-window 
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v1
+        with: # the final result should be called Island.zip
+          name: Island
+          path: build/linux


### PR DESCRIPTION
I tried to make a workflow for the mod. I'm trying to produce a downloadable Island.zip file from the Mod directory. I am not sure if this is what you had in mind for this CI. Can we do this even though we gitignored the .import files?

Fixes related issue #61  

### :ballot_box_with_check: Definition of Done checklist
- [ ] Meaningful title and valuable description in pull request
- [ ] Code change tested manually if not covered by automated tests
- [ ] Pull request linked to one or more issues/stories
- [ ] Acceptance criteria of the linked stories satisfied
- [ ] Code change comprehended by those who approved it
- [ ] State of target branch maintained or improved after the code change
